### PR TITLE
Add support for additional_fields hash to ActionCreateAction

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,10 @@ create an action
 
 ```ruby
 action = en.action.create(client_id: 123, campaign_id: 123, form_id: 123, first_name: 'George',
-                                        last_name: 'Washington', city: 'Detroit', country: country_code, country_name: 'United States',
-                                        email: 'george@washington.com', language_code: 'EN', address_line_1: 'address1', address_line_2: 'address2',
-                                        post_code: '02052', state: 'MI', mobile_phone: '518-207-6768', originating_action: 'xxx')
+                          last_name: 'Washington', city: 'Detroit', country: country_code, country_name: 'United States',
+                          email: 'george@washington.com', address_line_1: 'address1', address_line_2: 'address2',
+                          post_code: '02052', state: 'MI', mobile_phone: '518-207-6768', originating_action: 'xxx',
+                          additional_fields: {'Some Custom Field Name': 'field value'})
 
 action.valid?
 => true

--- a/lib/engaging_networks/action_create_action.rb
+++ b/lib/engaging_networks/action_create_action.rb
@@ -1,7 +1,7 @@
 module EngagingNetworks
   class ActionCreateAction < ActionModel
     attr_accessor :client_id, :campaign_id, :form_id, :title, :first_name, :last_name, :city, :country, :country_name,  :email, :address_line_1,
-                  :address_line_2, :post_code, :state, :mobile_phone, :originating_action, :result, :raw_response
+                  :address_line_2, :post_code, :state, :mobile_phone, :originating_action, :additional_fields, :result, :raw_response
 
     validates :client_id,  presence: true, numericality: true
     validates :campaign_id, presence: true, numericality: true
@@ -33,7 +33,7 @@ module EngagingNetworks
         'State' => state,
         'Mobile Phone' => mobile_phone,
         'Originating Action' => originating_action
-      }
+      }.merge(additional_fields)
     end
   end
 end

--- a/spec/engaging_networks/action_create_action_spec.rb
+++ b/spec/engaging_networks/action_create_action_spec.rb
@@ -5,11 +5,14 @@ describe EngagingNetworks::ActionCreateAction do
   let(:init_hash) { {client_id: 123, campaign_id: 123, form_id: 123, first_name: 'George',
                      last_name: 'Washington', city: 'Detroit', country: country_code, country_name: 'United States',
                      email: 'george@washington.com', address_line_1: 'address1', address_line_2: 'address2',
-                     post_code: '02052', state: 'MI', mobile_phone: '518-207-6768', originating_action: 'xxx' } }
+                     post_code: '02052', state: 'MI', mobile_phone: '518-207-6768', originating_action: 'xxx',
+                     additional_fields: additional_fields } }
 
   subject { EngagingNetworks::ActionCreateAction.new(init_hash) }
 
   describe 'initialization' do
+    let(:additional_fields) { {} }
+
     specify { expect(subject.valid?).to be_truthy }
 
     context 'invalid country code' do
@@ -19,6 +22,17 @@ describe EngagingNetworks::ActionCreateAction do
   end
 
   describe 'to_params' do
-    specify { expect(subject.to_params['First name']).to eq('George') }
+    context 'no additional fields' do
+      let(:additional_fields) { {} }
+
+      specify { expect(subject.to_params['First name']).to eq('George') }
+    end
+
+    context 'some additional fields' do
+      let(:additional_fields) { {'Interested In Volunteering' => 'y', 'Shirt Size' => 'XXL'} }
+
+      specify { expect(subject.to_params['Interested In Volunteering']).to eq('y') }
+      specify { expect(subject.to_params['Shirt Size']).to eq('XXL') }
+    end
   end
 end

--- a/spec/engaging_networks/action_spec.rb
+++ b/spec/engaging_networks/action_spec.rb
@@ -11,12 +11,17 @@ describe EngagingNetworks::Action do
       { client_id: 123, campaign_id: 123, form_id: 123, first_name: 'George',
       last_name: 'Washington', city: 'Detroit', country: 'US', country_name: 'United States',
       email: 'george@washington.com', address_line_1: 'address1', address_line_2: 'address2',
-      post_code: '02052', state: 'MI', mobile_phone: '518-207-6768', originating_action: 'xxx'}
+      post_code: '02052', state: 'MI', mobile_phone: '518-207-6768', originating_action: 'xxx',
+      additional_fields: {}}
     end
 
     before(:each) do
-      stub_request(:post, request_path).with(:query => {'format' => 'json'}, :body => {"Address+Line+1"=>"address1", "Address+Line+2"=>"address2", "City"=>"Detroit", "Country"=>"US", "Country+Name"=>"United States", "Email+address"=>"george@washington.com", "First+name"=>"George", "Last+name"=>"Washington", "Mobile+Phone"=>"518-207-6768", "Originating+Action"=>"xxx", "Post+Code"=>"02052", "State"=>"MI", "Title"=>"", "ea.AJAX.submit"=>"true", "ea.campaign.id"=>"123", "ea.campaign.mode"=>"DEMO", "ea.clear.campaign.session.id"=>"true", "ea.client.id"=>"123", "ea.form.id"=>"123", "ea.retain.account.session.error"=>"true", "ea.submitted.page"=>"1", "ea_javascript_enabled"=>"true", "ea_requested_action"=>"ea_submit_user_form", "v"=>"c%3AshowBuild"},
-             :headers => {'Accept'=>'application/json;q=0.1', 'Accept-Charset'=>'utf-8', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'EngagingNetworksGem'}).
+      stub_request(:post, request_path).with(:query => {'format' => 'json'},
+                                             :headers => {'Accept'=>'application/json;q=0.1',
+                                                          'Accept-Charset'=>'utf-8',
+                                                          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                                                          'Content-Type'=>'application/x-www-form-urlencoded',
+                                                          'User-Agent'=>'EngagingNetworksGem'}).
         to_return(:body => body, :status => status, :headers => {:content_type => "text/json;charset=UTF-8"})
     end
 


### PR DESCRIPTION
This lets a caller add arbitrary additional data to an action, so that users with fields beyond the standard ones can sync their data.