### PR TITLE
Add support for counties and email confirmation field

### DIFF
--- a/engaging_networks.gemspec
+++ b/engaging_networks.gemspec
@@ -6,7 +6,7 @@
 
 Gem::Specification.new do |s|
   s.name = "engaging_networks"
-  s.version = "0.2.1"
+  s.version = "0.2.2"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]

--- a/lib/engaging_networks/action_create_action.rb
+++ b/lib/engaging_networks/action_create_action.rb
@@ -1,6 +1,6 @@
 module EngagingNetworks
   class ActionCreateAction < ActionModel
-    attr_accessor :client_id, :campaign_id, :form_id, :title, :first_name, :last_name, :city, :country, :country_name,  :email, :address_line_1,
+    attr_accessor :client_id, :campaign_id, :form_id, :title, :first_name, :last_name, :city, :country, :country_name,  :county, :email, :address_line_1,
                   :address_line_2, :post_code, :state, :mobile_phone, :originating_action, :additional_fields, :result, :raw_response, :opt_in
 
     validates :client_id,  presence: true, numericality: true
@@ -27,6 +27,7 @@ module EngagingNetworks
         'Last name' => last_name,
         'City' => city,
         'Country' => country,
+        'County' => county,
         'Country Name' => country_name,
         'Address Line 1' => address_line_1,
         'Address Line 2' => address_line_2,

--- a/lib/engaging_networks/action_create_action.rb
+++ b/lib/engaging_networks/action_create_action.rb
@@ -22,6 +22,7 @@ module EngagingNetworks
       hsh = {
         'Title' => title,
         'Email address' => email,
+        'Email addressConfirm' => email,
         'First name' => first_name,
         'Last name' => last_name,
         'City' => city,


### PR DESCRIPTION
This code has been in use by Uplift for over a year now, and it seems to work just fine for them. If it won't break anything for y'all, we'd love to have it merged back into your branch so we can include your gem in Speakout instead of this fork.

Caveat: I don't actually know what the email-confirm field does. I understand that it's not breaking anything for Uplift, but I just want to flag that.